### PR TITLE
Added discord support to social

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Icons for Social Media. Add the block to the config.
   snapchat         = ""
   pinterest        = ""
   telegram         = ""
+  discord          = "" # invite link
   # Email
   email            = ""
 ```

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -104,6 +104,7 @@ theme="materialize-bp-hugo-theme"
   snapchat         = ""
   pinterest        = ""
   telegram         = ""
+  discord          = "" # invite link
   # Email
   email            = ""
 

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -126,6 +126,10 @@
   <li class="list-inline-item"><a href="https://telegram.me/{{.}}" target="_blank" rel="noopener noreferrer" title="telegram" class="fab fa-telegram fa-2x white-text"></a></li>
 {{ end }}
 
+{{ with .Site.Social.discord }}
+  <li class="list-inline-item"><a href="{{.}}" target="_blank" rel="noopener noreferrer" title="Discord" class="fab fa-discord fa-2x white-text"></a></li>
+{{ end }}
+
 {{ with .Site.Social.twitch }}
   <li class="list-inline-item"><a href="https://twitch.tv/{{.}}" target="_blank" rel="noopener noreferrer" title="twitch" class="fab fa-twitch fa-2x white-text"></a></li>
 {{ end }}


### PR DESCRIPTION
I deliberately used the full invite url, rather than the unique part of it, because some servers publish their invite as a custom link; either a short url redirect, a pretty redirect from their own domain, or an anti-spam verification url (e.g. https://impactclient.net/discord.html).

A "standard" invite link looks like `discord.gg/JA397mC`.