### PR TITLE
Fix hugo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Other themes by Sebastian Pech: [Bootstrap-BP](https://github.com/spech66/bootst
   - [Update the theme](#update-the-theme)
   - [Run example site](#run-example-site)
   - [Configuration and theme specific settings](#configuration-and-theme-specific-settings)
-  - [Screenshots of cofigurations](#screenshots-of-cofigurations)
+  - [Screenshots of configurations](#screenshots-of-configurations)
   - [Google Analytics](#google-analytics)
   - [Page templates / archetypes](#page-templates--archetypes)
   - [Schema.org support](#schemaorg-support)
@@ -34,7 +34,7 @@ Other themes by Sebastian Pech: [Bootstrap-BP](https://github.com/spech66/bootst
 - Color themes
 - SEO best practices supported (Schema.org, open graph, meta information, ...)
 - Automatically resizing of images
-- One minified file per ressource only (js, css)
+- One minified file per resource only (js, css)
 - CDN font support (Google Fonts, ...)
 - Optional masonry-like mode for startpage
 - Settings for easy customization of layouts and features
@@ -95,7 +95,7 @@ Might be like one of this: red, pink, indigo lighten-2, cyan, blue, light-green,
 Currently the link color, pagination and blockquote color needs to be adjusted according to `main.css` too.
 Overwrite in your `/assets/css/custom.css` file.
 
-## Screenshots of cofigurations
+## Screenshots of configurations
 
 `startPageColumns = false`
 
@@ -133,7 +133,7 @@ Provide one author to enable the Schema.org support.
 
 This theme uses Hugos `feature/cover` name method to set the optimized feature image. The image named `*feature*` or `*cover*` is used for the posts featured image and get resized. This will also be in the Twitter Cards and Open Graph block.
 
-The header image is automatically added if there is a file called `*feature*` or `*cover*`. The first wildcard is prefered over the second one. If there are multiple images the first one is used.
+The header image is automatically added if there is a file called `*feature*` or `*cover*`. The first wildcard is preferred over the second one. If there are multiple images the first one is used.
 
 ```yaml
 # Site Config toml

--- a/exampleSite/README.md
+++ b/exampleSite/README.md
@@ -26,4 +26,4 @@ hugo server -t YOURTHEME
 - A headless bundle called `homepage` that you may want to use for single page applications. You can find instructions about headless bundles over [here](https://gohugo.io/content-management/page-bundles/#headless-bundle)
 - An `about.md` that is intended to provide the `/about/` page for a theme demo
 
-6. If you intend to build a theme that does not fit in the content structure provided in this repository, then you are still more than welcome to submit it for review at the [Hugo Themes](https://github.com/gohugoio/hugoThemes/issues) respository
+6. If you intend to build a theme that does not fit in the content structure provided in this repository, then you are still more than welcome to submit it for review at the [Hugo Themes](https://github.com/gohugoio/hugoThemes/issues) repository

--- a/exampleSite/content/post/005-theme-info/index.md
+++ b/exampleSite/content/post/005-theme-info/index.md
@@ -19,7 +19,7 @@ categories:
 
 ## Headline 2
 
-The header image is automatically added if there is a file called `*feature*` or `*cover*`. The first wildcard is prefered over the second one. If there are multiple images the first one is used.
+The header image is automatically added if there is a file called `*feature*` or `*cover*`. The first wildcard is preferred over the second one. If there are multiple images the first one is used.
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 

--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< twitter user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -13,7 +13,6 @@ ignoreErrors = ["error-remote-getjson"]
 footnoteReturnLinkContents = "^"
 
 # Theme specific examples
-author = "Sebastian Pech"
 copyright = "Sebastian Pech"
 enableRobotsTXT = true
 pygmentsCodeFences = true
@@ -51,7 +50,8 @@ theme="materialize-bp-hugo-theme"
   # js=["/js/test_site.js"]
   # css=["/css/test_site.css"]
   # csscdn=["https://fonts.googleapis.com/css?family=Concert+One|Roboto&display=swap"]
-
+  [params.author]
+    name = "Sebastian Pech"
 
 #[languages]
 #  [languages.en]


### PR DESCRIPTION
When previewing the example site with latest hugo version 0.124.1, an error is thrown, preventing preview of the site. This PR fixes that issue.
This PR fixes a few typos on the way, too.